### PR TITLE
Hide Kaliel's Tracker frame

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -60,6 +60,11 @@ WarpDeplete.defaultKeyDetailsState = {
   affixes = {}
 }
 
+-- Check if Kaliel's Tracker is loaded, since it creates a
+-- background frame for the objective window that will not be
+-- hidden if only the objective window itself is hidden.
+local KT = LibStub("AceAddon-3.0"):GetAddon("!KalielsTracker", true)
+
 function WarpDeplete:OnInitialize()
   local frames = {}
 
@@ -172,10 +177,16 @@ function WarpDeplete:Show()
   self.frames.root:Show()
   self:UpdateLayout()
   ObjectiveTrackerFrame:Hide()
+  if KT ~= nil then
+    KT.frame:Hide()
+  end
 end
 
 function WarpDeplete:Hide()
   self.frames.root:Hide()
+  if KT ~= nil then
+    KT.frame:Show()
+  end
   ObjectiveTrackerFrame:Show()
 end
 


### PR DESCRIPTION
If Kaliel's Tracker is enabled, WarpDeplete will not hide its base frame, leaving a background on the players screen. This change will also hide Kaliel's frame if the addon is enabled.