### PR TITLE
Fix remaining forces after pull showing 0 when not in pull

### DIFF
--- a/Util.lua
+++ b/Util.lua
@@ -50,8 +50,8 @@ function Util.formatForcesText(
       result = pullText .. "  " .. result
     end
   else
-    result = gsub(result, ":remainingcountafterpull:", 0)
-    result = gsub(result, ":remainingpercentafterpull:", "0" .. "%%")
+    result = gsub(result, ":remainingcountafterpull:", remainingCountText)
+    result = gsub(result, ":remainingpercentafterpull:", remainingPercentText .. "%%")
   end
 
   


### PR DESCRIPTION
This fixes an issue with the new `*afterpull` keywords showing 0 when not in an active pull.