### PR TITLE
Add ms precision to finished dungeon timer

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -445,18 +445,26 @@ function WarpDeplete:UpdateTimerDisplay()
   state.timerText = Util.formatTime_OnUpdate(self.timerState.current) ..
     " / " .. Util.formatTime_OnUpdate(self.timerState.limit)
 
-  if self.challengeState.challengeCompleted and self.timerState.current <= self.timerState.limit then
-    local blizzardTime = select(3, C_ChallengeMode.GetCompletionInfo())
-    state.timerText = Util.formatTimeMilliseconds(blizzardTime) ..
-            " / " .. Util.formatTime_OnUpdate(self.timerState.limit)
-    state.timerText = "|c" .. state.successColor .. state.timerText .. "|r"
-  elseif self.challengeState.challengeCompleted and self.timerState.current > self.timerState.limit then
-    local blizzardTime = select(3, C_ChallengeMode.GetCompletionInfo())
-    state.timerText = Util.formatTimeMilliseconds(blizzardTime) ..
-            " / " .. Util.formatTime_OnUpdate(self.timerState.limit)
-    state.timerText = "|c" .. state.expiredColor .. state.timerText .. "|r"
-  end
 
+  if self.challengeState.challengeCompleted then
+    local blizzardTime = select(3, C_ChallengeMode.GetCompletionInfo())
+    local blizzardTimeText = ''
+    if self.db.profile.showMillisecondsWhenDungeonCompleted then
+      blizzardTimeText = Util.formatTimeMilliseconds(blizzardTime)
+    else
+      blizzardTimeText = Util.formatTime(blizzardTime/1000)
+    end
+
+    if self.timerState.current <= self.timerState.limit then
+      state.timerText =  blizzardTimeText ..
+              " / " .. Util.formatTime_OnUpdate(self.timerState.limit)
+      state.timerText = "|c" .. state.successColor .. state.timerText .. "|r"
+    elseif self.timerState.current > self.timerState.limit then
+      state.timerText =  blizzardTimeText ..
+              " / " .. Util.formatTime_OnUpdate(self.timerState.limit)
+      state.timerText = "|c" .. state.expiredColor .. state.timerText .. "|r"
+    end
+  end
   self.frames.root.timerText:SetText(state.timerText)
 
   for i = 1, 3 do

--- a/Display.lua
+++ b/Display.lua
@@ -446,8 +446,14 @@ function WarpDeplete:UpdateTimerDisplay()
     " / " .. Util.formatTime_OnUpdate(self.timerState.limit)
 
   if self.challengeState.challengeCompleted and self.timerState.current <= self.timerState.limit then
+    local blizzardTime = select(3, C_ChallengeMode.GetCompletionInfo())
+    state.timerText = Util.formatTimeMilliseconds(blizzardTime) ..
+            " / " .. Util.formatTime_OnUpdate(self.timerState.limit)
     state.timerText = "|c" .. state.successColor .. state.timerText .. "|r"
   elseif self.challengeState.challengeCompleted and self.timerState.current > self.timerState.limit then
+    local blizzardTime = select(3, C_ChallengeMode.GetCompletionInfo())
+    state.timerText = Util.formatTimeMilliseconds(blizzardTime) ..
+            " / " .. Util.formatTime_OnUpdate(self.timerState.limit)
     state.timerText = "|c" .. state.expiredColor .. state.timerText .. "|r"
   end
 
@@ -474,7 +480,6 @@ function WarpDeplete:UpdateTimerDisplay()
       else
         state.color = state.successColor
       end
-
       state.timeText = "|c" .. state.color .. state.timeText .. "|r"
     end
 

--- a/Options.lua
+++ b/Options.lua
@@ -121,7 +121,8 @@ local defaults = {
     objectivesOffset = 4,
 
     -- Utility options
-    insertKeystoneAutomatically = true
+    insertKeystoneAutomatically = true,
+    showMillisecondsWhenDungeonCompleted = true
   }
 }
 
@@ -331,6 +332,7 @@ function WarpDeplete:InitOptions()
       general = group(L["General"], false, {
         lineBreak(),
         toggle(L["Insert keystone automatically"], "insertKeystoneAutomatically", "UpdateLayout"),
+        toggle(L["Show millisecond precision after dungeon completion"], "showMillisecondsWhenDungeonCompleted", "UpdateLayout"),
         lineBreak(),
 
         group(L["Forces Display"], true, {

--- a/Util.lua
+++ b/Util.lua
@@ -96,6 +96,13 @@ function Util.formatTime(time)
   return ("%d:%02d"):format(timeMin, timeSec)
 end
 
+function Util.formatTimeMilliseconds(time)
+  local timeMin = math.floor(time / 60000)
+  local timeSec = math.floor(time / 1000 - (timeMin * 60))
+  local timeMilliseconds = math.floor(time - (timeMin * 60000) - (timeSec * 1000))
+  return ("%d:%02d.%03d"):format(timeMin, timeSec, timeMilliseconds)
+end
+
 local formatTime_OnUpdate_state = {}
 function Util.formatTime_OnUpdate(time)
   formatTime_OnUpdate_state.timeMin = math.floor(time / 60)


### PR DESCRIPTION
Trying to (kind of) add the request made in #35, this adds the exact completion time as informed by the blizzard api after dungeon completion, and shows it with ms precision.

How it looks when timing a key
![img](https://i.imgur.com/qapJuzl.gif)