### PR TITLE
Add default value for :percentafterpull: placeholder

### DIFF
--- a/Util.lua
+++ b/Util.lua
@@ -55,6 +55,7 @@ function Util.formatForcesText(
   else
     result = gsub(result, ":remainingcountafterpull:", remainingCountText)
     result = gsub(result, ":remainingpercentafterpull:", remainingPercentText .. "%%")
+    result = gsub(result, ":percentafterpull:", percentText .. "%%")
   end
 
   if completedTime and result then


### PR DESCRIPTION
If :percentafterpull: ist not calculated due to pull not having count, we replace it with the current force percentage as a default value. This is a small fixup for #53 which I noticed while running some keys :)

I also noticed some oddities after key completion (percentage being displayed as 0%), but that is most probably due to forces being completed and pulls not being updated after (?).