### PR TITLE
Timings fixes

### DIFF
--- a/Display.lua
+++ b/Display.lua
@@ -647,6 +647,7 @@ function WarpDeplete:UpdateObjectivesDisplay()
 
   for i, boss in ipairs(self.objectivesState) do
     local objectiveStr = boss.name
+    local timeDiffStr = ""
 
     if boss.time ~= nil then
       objectiveStr = Util.colorText(boss.name, completionColor)
@@ -656,44 +657,27 @@ function WarpDeplete:UpdateObjectivesDisplay()
       local completionTimeStr = "[" .. Util.formatTime(boss.time) .. "]"
       completionTimeStr = Util.colorText(completionTimeStr, completionColor)
 
-      if alignStart then
-        objectiveStr = completionTimeStr .. " " .. objectiveStr
-      else
-        objectiveStr = objectiveStr .. " " .. completionTimeStr
+      if timingsDisplayStyle ~= "hidden" then
+        local diff = nil
+        if timingsDisplayStyle == "bestDiff" then
+          local bestTime = self:GetBestTime(i)
+          if bestTime ~= nil then diff = boss.time - bestTime end
+        elseif timingsDisplayStyle == "lastDiff" then
+          local lastTime = self:GetLastTime(i)
+          if lastTime ~= nil then diff = boss.time - lastTime end
+        end
+
+        if diff ~= nil then
+          local color = diff <= 0 and self.db.profile.timingsImprovedTimeColor or self.db.profile.timingsWorseTimeColor
+          timeDiffStr = "[" .. Util.colorText(Util.formatTime(diff, true), color) .. "]"
+        end
       end
 
-      -- TODO(happens): This is temporarily disabled, due to some
-      -- bugs with the current implementation. We basically need
-      -- to find out time differences for the current run at the
-      -- time when the boss is cleared and then update them in the
-      -- database, and from that point on only display the values
-      -- saved for the current run.
-      -- Otherwise, on each consecutive update we find the new
-      -- best/last times for the current run and the difference
-      -- will always be 0.
-      --
-      -- if timingsDisplayStyle ~= "hidden" then
-      --   local bestDiffStr = ""
-
-      --   local diff = nil
-      --   if timingsDisplayStyle == "bestDiff" then
-      --     local bestTime = self:GetBestTime(i)
-      --     if bestTime ~= nil then diff = boss.time - bestTime end
-      --   elseif timingsDisplayStyle == "lastDiff" then
-      --     local lastTime = self:GetLastTime(i)
-      --     if lastTime ~= nil then diff = boss.time - lastTime end
-      --   end
-
-      --   if diff ~= nil then
-      --     local color = diff <= 0 and
-      --       self.db.profile.timingsImprovedTimeColor or
-      --       self.db.profile.timingsWorseTimeColor
-
-      --     bestDiffStr = "[|c" .. color ..
-      --       Util.formatTime(diff, true) .. "|r|c" ..
-      --       completionColor .. "]"
-      --   end
-      -- end
+      if alignStart then
+        objectiveStr = timeDiffStr .." " .. completionTimeStr .. " " .. objectiveStr
+      else
+        objectiveStr = objectiveStr .. " " .. completionTimeStr .." " .. timeDiffStr
+      end
     end
 
     -- TODO allow users to provide a custom format string for the objectiveStr

--- a/Options.lua
+++ b/Options.lua
@@ -458,14 +458,15 @@ function WarpDeplete:InitOptions()
             end,
             width = 1
           },
-          {
-            type = "toggle",
-            name = L["Only record completed runs"],
-            desc = L["When active, timestamps are only recorded once the key has been finished"],
-            get = function(info) return WarpDeplete.db.profile.timingsOnlyCompleted end,
-            set = function(info, value) WarpDeplete.db.profile.timingsOnlyCompleted = value end,
-            width = 2
-          }
+          -- TODO: Temporarilty disabled (see Timings.lua)
+          -- {
+          --   type = "toggle",
+          --   name = L["Only record completed runs"],
+          --   desc = L["When active, timestamps are only recorded once the key has been finished"],
+          --   get = function(info) return WarpDeplete.db.profile.timingsOnlyCompleted end,
+          --   set = function(info, value) WarpDeplete.db.profile.timingsOnlyCompleted = value end,
+          --   width = 2
+          -- }
         })
       }, { order = 3 }),
 


### PR DESCRIPTION
@happenslol I'm sorry. I should not have done this late at night. And during my testing, I missed a lot of stuff.

I've seen your TODO note on the disabled timings. The timings actually work fine apart from one feature (which should be default disabled). When applying your requested changes I introduced a bug that caused said feature to be default enabled.

That feature is the ability to record timings as an objective gets completed. That feature causes the problem you described in your TODO message. When this feature is disabled, timings are only updated after completing the keystone. In that case, no further objective updates should occur.

I've noticed an additional bug that caused the lower keystone timings (when the current keystone has no recordings) to be determined but not used.

The current state of this PR fixes these bugs and disables the feature for recording timings on objective completion. I have now thought a little bit about it and could not come up with a satisfying solution.

## Possible solutions for record on objective completion

**1. Keep updating as previously and store calculated time differences in a cache and reuse when updating the objective display**

Problem: When a player reloads that cache would get lost and we'd have the same issue as we have now. Maybe we could save when the addon gets disabled and re-load when it gets re-enabled but that could cause problems when the addon gets disabled in RunA and re-enabled in RunB (because humans do human things), we would somehow have to verify if the cache belongs to the current run. Using only map, keystone and affixes feels to unsafe IMO.

**2. Write timing updates to a pending object and overwrite the actual objects when we detect the player leaving the instance or keystone completion**

Problem: Players might leave instances to switch spec/talents

I will test this code today.