### PR TITLE
Re-implement objective clear timings

### DIFF
--- a/Comms.lua
+++ b/Comms.lua
@@ -1,6 +1,3 @@
-local Util = WarpDeplete.Util
-
-
 -- Format: "current|type"
 -- current: number
 -- type: "blizz" or "gettime", depending on whether or not the time
@@ -60,7 +57,7 @@ function WarpDeplete:OnTimerSyncResponse(prefix, message, dist, sender)
 
   self:PrintDebug("Received time from " .. sender .. ": "
     .. current .. ", type: " .. typeRaw)
-  
+
   if self.timerState.isBlizzardTimer and not isBlizzard then
     self:PrintDebug("Updating timer")
     local deaths = C_ChallengeMode.GetDeathCount()
@@ -92,17 +89,18 @@ function WarpDeplete:OnObjectiveSyncRequest(prefix, message, dist, sender)
 end
 
 function WarpDeplete:OnObjectiveSyncResponse(prefix, message, dist, sender)
+  self:PrintDebug("Received objective sync from " .. sender .. ": " .. message)
   local parts = {strsplit("|", message)}
 
   for i, objTimeRaw in ipairs(parts) do
     local objTime = tonumber(objTimeRaw)
 
     if self.objectivesState[i] and objTime >= 0 then
+      self:PrintDebug("Sync: Updating objective " .. i .. " time to " .. objTime)
       self.objectivesState[i].time = objTime
     end
   end
 
-  self:UpdateTimings()
   self:UpdateObjectivesDisplay()
 end
 

--- a/Comms.lua
+++ b/Comms.lua
@@ -87,7 +87,7 @@ function WarpDeplete:OnObjectiveSyncRequest(prefix, message, dist, sender)
   -- the process of getting times from other users
   if not hasAny then return end
 
-  local text = Util.joinStrings(completionTimes, "|")
+  local text = table.concat(completionTimes, "|")
   self:SendCommMessage(objectiveResponsePrefix, text, "WHISPER", sender, "ALERT")
 end
 
@@ -114,7 +114,7 @@ function WarpDeplete:BroadcastDeath()
   self:AddDeathDetails(time, playerName, playerClass)
 
   local messageTable = {tostring(time), playerName, playerClass}
-  local message = Util.joinStrings(messageTable, "|")
+  local message = table.concat(messageTable, "|")
   self:PrintDebug("Sending death broadcast")
   self:SendCommMessage(deathBroadcastPrefix, message, "PARTY", nil, "ALERT")
 end

--- a/Comms.lua
+++ b/Comms.lua
@@ -59,7 +59,7 @@ function WarpDeplete:OnTimerSyncResponse(prefix, message, dist, sender)
   local current = tonumber(currentRaw)
 
   self:PrintDebug("Received time from " .. sender .. ": "
-    .. tonumber(current) .. ", type: " .. typeRaw)
+    .. current .. ", type: " .. typeRaw)
   
   if self.timerState.isBlizzardTimer and not isBlizzard then
     self:PrintDebug("Updating timer")

--- a/Core.lua
+++ b/Core.lua
@@ -141,16 +141,23 @@ function WarpDeplete:EnableDemoMode()
   self:ResetState()
   self.challengeState.demoModeActive = true
 
-  local objectives = {}
-  for i = 1, 5 do
-    objectives[i] = { name = L["Test Boss Name"] .. " " .. i }
+  self:SetObjectives({
+    { name = L["Test Boss Name"] .. " 1", time = 520 },
+    { name = L["Test Boss Name"] .. " 2", time = 1040 },
+    { name = L["Test Boss Name"] .. " 3", time = 1560 },
+    { name = L["Test Boss Name"] .. " 4" },
+    { name = L["Test Boss Name"] .. " 5" },
+  })
 
-    if i < 4 then
-      objectives[i].time = 520 * i
-    end
-  end
+  self.db.char.currentRunTimings = {
+    mapId = "demo",
+    objectives = {
+      { lastTime = 560, lastBest = 560, newTime = 520, bestUpdated = true },
+      { lastTime = 1260, lastBest = 980, newTime = 1040, bestUpdated = false },
+      { lastTime = 1600, lastBest = 1580, newTime = 1560, bestUpdated = true },
+    }
+  }
 
-  self:SetObjectives(objectives)
   self:SetKeyDetails(
     30,
     {

--- a/Core.lua
+++ b/Core.lua
@@ -271,4 +271,6 @@ function WarpDeplete:ResetState()
   self.challengeState = Util.copy(self.defaultChallengeState)
   self.objectivesState = Util.copy(self.defaultObjectivesState)
   self.keyDetailsState = Util.copy(self.defaultKeyDetailsState)
+
+  self:HideGlow()
 end

--- a/Core.lua
+++ b/Core.lua
@@ -60,7 +60,7 @@ WarpDeplete.defaultObjectivesState = {}
 WarpDeplete.defaultKeyDetailsState = {
   level = 0,
   affixes = {},
-  affixIds = {}
+  mapId = nil,
 }
 
 -- Check if Kaliel's Tracker is loaded, since it creates a
@@ -151,7 +151,16 @@ function WarpDeplete:EnableDemoMode()
   end
 
   self:SetObjectives(objectives)
-  self:SetKeyDetails(30, {L["Tyrannical"], L["Bolstering"], L["Spiteful"], L["Thundering"]}, {9, 7, 123, 132})
+  self:SetKeyDetails(
+    30,
+    {
+      { id = 9, name = L["Tyrannical"] },
+      { id = 7, name = L["Bolstering"] },
+      { id = 123, name = L["Spiteful"] },
+      { id = 132, name = L["Thundering"] },
+    },
+    "demo"
+  )
 
   self:SetTimerLimit(35 * 60)
   self:SetTimerRemaining(20 * 60)

--- a/DB.lua
+++ b/DB.lua
@@ -2,6 +2,7 @@ local defaults = {
   global = {
     DEBUG = false,
     mdtAlertShown = false,
+    dbVersion = 1,
   },
 
   profile = {
@@ -132,44 +133,51 @@ local defaults = {
 
   char = {
     --[[
-    Used to save timing differences for the
-    current run. We might want to update the values
-    in the database right away when a boss is killed
-    or we might not, so it's safest to calculate the
-    difference that will be displayed and persist it,
-    so it will stay there even if the user disconnects.
+      Used to save timing differences for the
+      current run. We might want to update the values
+      in the database right away when a boss is killed
+      or we might not, so it's safest to calculate the
+      difference that will be displayed and persist it,
+      so it will stay there even if the user disconnects.
 
-    We reset this whenever a new challenge is started,
-    or if we enter demo mode. Since demo mode can't be
-    enabled during a running challenge, we're also safe
-    to clear it then.
-    We also clear this whenever the user enters a challenge
-    and the map id doesn't match the current map id.
-    
-    Layout: {
-      mapId = <number> or <string>,
-      [objectiveId] = {
-        diffToBest = <string>,
-        diffToLast = <string>,
+      We basically never need to reset this, and will only
+      do so when entering demo mode (which will not overwrite
+      anything important since demo mode can't be activated
+      during an active challenge).
+      This works because we never show this unless the objective
+      is completed, and it will always be set anew when the
+      objective is completed. So if a value is set here, we
+      can assume that the objective was cleared during the current
+      run and the time saved here is up to date.
+      
+      Layout: {
+        mapId = <number> or <string>,
+        objectives = {
+          [objectiveId] = {
+            diffToBest = <number>,
+            diffToLast = <number>,
+          }
+        },
       }
-    }
     --]]
-    currentInstanceTimings = {},
+    currentTimingDiffs = {},
 
     --[[
-    Used to save the best and last objective clear
-    times for each dungeon.
+      Used to save the best and last objective clear
+      times for each dungeon.
 
-    Layout: { 
-      [mapId] = { 
-        [keystoneLevel] = { 
-          [affixId] = { 
-            best = { objectiveIndex = <time> }, 
-            last = { objectiveIndex = <time> },
+      Layout: { 
+        [mapId] = { 
+          [keystoneLevel] = { 
+            [affixId] = { 
+              [objectiveIndex] = {
+                best = <number>,
+                last = <number>,
+              }
+            } 
           } 
-        } 
+        }
       }
-    }
     --]]
     timings = {},
   }

--- a/DB.lua
+++ b/DB.lua
@@ -127,8 +127,8 @@ local defaults = {
     timingsEnabled = true,
     timingsOnlyCompleted = true,
     timingsDisplayStyle = "bestDiff",
-    timingsImprovedTimeColor = "FF00D200",
-    timingsWorseTimeColor = "FFF50000"
+    timingsImprovedTimeColor = "FFF3E600",
+    timingsWorseTimeColor = "FFFF5614"
   },
 
   char = {
@@ -153,12 +153,11 @@ local defaults = {
       Layout: {
         mapId = <number> or <string>,
         objectives = {
-          [objectiveId] = {
+          [objectiveIndex] = {
             lastTime = <number> | nil,
+            lastBest = <number> | nil,
             newTime = <number>,
             bestUpdated = <boolean>,
-            lastBest = <number> | nil,
-            newBest = <number> | nil,
           }
         },
       }

--- a/DB.lua
+++ b/DB.lua
@@ -131,23 +131,47 @@ local defaults = {
   },
 
   char = {
-    --[[ Structure of the timings table
-       timings = { 
-         dungeonId = { 
-           keystoneLevel = { 
-             1stAffixId = { 
-               best = { 
-                 objectiveIndex = <time> 
-               }, 
-               last = { 
-                 objectiveIndex = <time> 
-               } 
-             } 
-           } 
-         }
-       }
+    --[[
+    Used to save timing differences for the
+    current run. We might want to update the values
+    in the database right away when a boss is killed
+    or we might not, so it's safest to calculate the
+    difference that will be displayed and persist it,
+    so it will stay there even if the user disconnects.
+
+    We reset this whenever a new challenge is started,
+    or if we enter demo mode. Since demo mode can't be
+    enabled during a running challenge, we're also safe
+    to clear it then.
+    We also clear this whenever the user enters a challenge
+    and the map id doesn't match the current map id.
+    
+    Layout: {
+      mapId = <number> or <string>,
+      [objectiveId] = {
+        diffToBest = <string>,
+        diffToLast = <string>,
+      }
+    }
     --]]
-    timings = {}
+    currentInstanceTimings = {},
+
+    --[[
+    Used to save the best and last objective clear
+    times for each dungeon.
+
+    Layout: { 
+      [mapId] = { 
+        [keystoneLevel] = { 
+          [affixId] = { 
+            best = { objectiveIndex = <time> }, 
+            last = { objectiveIndex = <time> },
+          } 
+        } 
+      }
+    }
+    --]]
+    timings = {},
   }
 }
 

--- a/DB.lua
+++ b/DB.lua
@@ -84,7 +84,7 @@ local defaults = {
     bar3TextureColor = "FF979797",
     forcesTextureColor = "FFBB9E22",
     forcesOverlayTextureColor = "FFFF5515",
-    
+
     -- Font sizes for text parts
     deathsFontSize = 16,
     timerFontSize = 34,
@@ -136,9 +136,9 @@ local defaults = {
       Used to save timing differences for the
       current run. We might want to update the values
       in the database right away when a boss is killed
-      or we might not, so it's safest to calculate the
-      difference that will be displayed and persist it,
-      so it will stay there even if the user disconnects.
+      or we might not, so it's safest to persist the values,
+      before and after they were changed, so it will stay
+      there even if the user disconnects.
 
       We basically never need to reset this, and will only
       do so when entering demo mode (which will not overwrite
@@ -154,13 +154,16 @@ local defaults = {
         mapId = <number> or <string>,
         objectives = {
           [objectiveId] = {
-            diffToBest = <number>,
-            diffToLast = <number>,
+            lastTime = <number> | nil,
+            newTime = <number>,
+            bestUpdated = <boolean>,
+            lastBest = <number> | nil,
+            newBest = <number> | nil,
           }
         },
       }
     --]]
-    currentTimingDiffs = {},
+    currentRunTimings = {},
 
     --[[
       Used to save the best and last objective clear

--- a/Display.lua
+++ b/Display.lua
@@ -99,7 +99,6 @@ end
 
 function WarpDeplete:CreateProgressBar(frame)
   local result = {}
-  local progress = 0
 
   local barFrame = CreateFrame("Frame", nil, frame, BackdropTemplateMixin and "BackdropTemplate")
   result.frame = barFrame
@@ -248,7 +247,7 @@ function WarpDeplete:UpdateLayout()
   keyDetailsText:SetJustifyH(alignRight and "RIGHT" or "LEFT")
   r, g, b = Util.hexToRGB(self.db.profile.keyDetailsColor)
   keyDetailsText:SetTextColor(r, g, b, 1)
-  
+
   -- Key level Text
   local keyText = self.frames.root.keyText
   keyText:SetFont(self.LSM:Fetch("font", keyFont), keyFontSize, keyFontFlags)
@@ -284,7 +283,7 @@ function WarpDeplete:UpdateLayout()
 
   -- Bars
   local timerBarPixelAdjust = 0.5
-  local r, g, b = Util.hexToRGB(self.db.profile.timerRunningColor)
+  r, g, b = Util.hexToRGB(self.db.profile.timerRunningColor)
 
   -- +3 bar
   local bar3Width = barWidth / 100 * 60
@@ -343,7 +342,7 @@ function WarpDeplete:UpdateLayout()
 
   -- Forces bar
   local forcesBarPixelAdjust = 0.5
-  local r, g, b = Util.hexToRGB(self.db.profile.forcesColor)
+  r, g, b = Util.hexToRGB(self.db.profile.forcesColor)
   self.forces:SetLayout(self.db.profile.forcesTexture, self.db.profile.forcesTextureColor,
     barWidth, barHeight + forcesBarPixelAdjust, 0, -barPadding - barHeight / 2)
   self.forces.text:SetFont(self.LSM:Fetch("font", forcesFont), forcesFontSize, forcesFontFlags)
@@ -376,7 +375,7 @@ function WarpDeplete:UpdateLayout()
     objectiveText:SetFont(self.LSM:Fetch("font", objectivesFont), objectivesFontSize, objectivesFontFlags)
     objectiveText:SetNonSpaceWrap(false)
     objectiveText:SetJustifyH(alignRight and "RIGHT" or "LEFT")
-    local r, g, b = Util.hexToRGB(self.db.profile.objectivesColor)
+    r, g, b = Util.hexToRGB(self.db.profile.objectivesColor)
     objectiveText:SetTextColor(r, g, b, 1)
     objectiveText:SetPoint(
       alignRight and "TOPRIGHT" or "TOPLEFT",
@@ -563,7 +562,7 @@ function WarpDeplete:UpdateForcesDisplay()
       self.forcesState.completed and self.forcesState.completedTime or nil
     )
   )
-  self:UpdateGlow() 
+  self:UpdateGlow()
 end
 
 function WarpDeplete:UpdateGlowAppearance()
@@ -575,7 +574,7 @@ function WarpDeplete:UpdateGlowAppearance()
   self:HideGlow()
   self:ShowGlow()
 end
-  
+
 function WarpDeplete:UpdateGlow()
   if self.forcesState.glowActive and (
     self.challengeState.challengeCompleted or
@@ -662,38 +661,31 @@ function WarpDeplete:UpdateObjectivesDisplay()
         objectiveStr = objectiveStr .. " " .. completionTimeStr
       end
 
-      -- TODO(happens): This is temporarily disabled, due to some
-      -- bugs with the current implementation. We basically need
-      -- to find out time differences for the current run at the
-      -- time when the boss is cleared and then update them in the
-      -- database, and from that point on only display the values
-      -- saved for the current run.
-      -- Otherwise, on each consecutive update we find the new
-      -- best/last times for the current run and the difference
-      -- will always be 0.
-      --
-      -- if timingsDisplayStyle ~= "hidden" then
-      --   local bestDiffStr = ""
+      if self.db.profile.timingsEnabled then
+        local timeDiff = nil
 
-      --   local diff = nil
-      --   if timingsDisplayStyle == "bestDiff" then
-      --     local bestTime = self:GetBestTime(i)
-      --     if bestTime ~= nil then diff = boss.time - bestTime end
-      --   elseif timingsDisplayStyle == "lastDiff" then
-      --     local lastTime = self:GetLastTime(i)
-      --     if lastTime ~= nil then diff = boss.time - lastTime end
-      --   end
+        if timingsDisplayStyle == "best" then
+          timeDiff = self:GetBestTimeDifference(i)
+        elseif timingsDisplayStyle == "last" then
+          timeDiff = self:GetLastTimeDifference(i)
+        end
 
-      --   if diff ~= nil then
-      --     local color = diff <= 0 and
-      --       self.db.profile.timingsImprovedTimeColor or
-      --       self.db.profile.timingsWorseTimeColor
+        if timeDiff ~= nil then
+          local timeDiffColor = self.db.profile.timingsWorseColor
+          if timeDiff < 0 then
+            timeDiffColor = self.db.profile.timingsImprovedColor
+          end
 
-      --     bestDiffStr = "[|c" .. color ..
-      --       Util.formatTime(diff, true) .. "|r|c" ..
-      --       completionColor .. "]"
-      --   end
-      -- end
+          local timeDiffStr = Util.formatTime(timeDiff, true)
+          timeDiffStr = Util.colorText(timeDiffStr, timeDiffColor)
+
+          if alignStart then
+            objectiveStr = timeDiffStr .. " " .. objectiveStr
+          else
+            objectiveStr = objectiveStr .. " " .. timeDiffStr
+          end
+        end
+      end
     end
 
     -- TODO allow users to provide a custom format string for the objectiveStr

--- a/Display.lua
+++ b/Display.lua
@@ -701,11 +701,12 @@ function WarpDeplete:UpdateObjectivesDisplay()
   end
 end
 
--- Expects level as number and affixes as string array, e.g. {"Tyrannical", "Bolstering"}
-function WarpDeplete:SetKeyDetails(level, affixes, affixIds)
+-- Expects level as number and affixes as an array of names and ids,
+-- e.g. {{ id = 0, name = "Tyrannical" }, { id = 1, name = "Bolstering" }}
+function WarpDeplete:SetKeyDetails(level, affixes, mapId)
   self.keyDetailsState.level = level
   self.keyDetailsState.affixes = affixes
-  self.keyDetailsState.affixIds = affixIds
+  self.keyDetailsState.mapId = mapId
 
   self:UpdateKeyDetailsDisplay()
 end
@@ -714,7 +715,12 @@ function WarpDeplete:UpdateKeyDetailsDisplay()
   local key = ("[%d]"):format(self.keyDetailsState.level)
   self.frames.root.keyText:SetText(key)
 
-  local affixesStr = Util.joinStrings(self.keyDetailsState.affixes or {}, " - ")
+  local affixNames = {}
+  for _, affix in ipairs(self.keyDetailsState.affixes) do
+    affixNames[#affixNames + 1] = affix.name
+  end
+
+  local affixesStr = Util.joinStrings(affixNames, " - ")
   local keyDetails = ("%s"):format(affixesStr)
   self.frames.root.keyDetailsText:SetText(keyDetails)
 end

--- a/Display.lua
+++ b/Display.lua
@@ -720,7 +720,7 @@ function WarpDeplete:UpdateKeyDetailsDisplay()
     affixNames[#affixNames + 1] = affix.name
   end
 
-  local affixesStr = Util.joinStrings(affixNames, " - ")
+  local affixesStr = table.concat(affixNames, " - ")
   local keyDetails = ("%s"):format(affixesStr)
   self.frames.root.keyDetailsText:SetText(keyDetails)
 end

--- a/Display.lua
+++ b/Display.lua
@@ -531,9 +531,11 @@ function WarpDeplete:SetForcesCurrent(currentCount)
   local currentPercent = self.forcesState.totalCount > 0
     and self.forcesState.currentCount / self.forcesState.totalCount or 0
 
-  if currentPercent > 1.0 then currentPercent = 1.0 end
-  self.forcesState.currentPercent = currentPercent
+  if currentPercent > 1.0 or self.forcesState.completed then
+    currentPercent = 1.0
+  end
 
+  self.forcesState.currentPercent = currentPercent
   self:UpdateForcesDisplay()
 end
 
@@ -580,12 +582,19 @@ function WarpDeplete:UpdateGlow()
     self.challengeState.challengeCompleted or
     self.forcesState.completed
   ) then
+    self:PrintDebug("Hiding glow after challenge complete")
     self:HideGlow()
   end
 
   local percentBeforePull = self.forcesState.currentPercent
   local percentAfterPull = percentBeforePull + self.forcesState.pullPercent
-  local shouldGlow = percentBeforePull < 1 and percentAfterPull >= 1.0
+  local shouldGlow = percentBeforePull < 1.0 and percentAfterPull >= 1.0
+  -- self:PrintDebug(
+  --   "Updating glow: " ..
+  --   "percentBeforePull(" .. tostring(percentBeforePull) .. ") " ..
+  --   "percentAfterPull(" .. tostring(percentAfterPull) .. ") " ..
+  --   "shouldGlow(" .. tostring(shouldGlow) .. ")"
+  -- )
 
   -- Already in the correct state
   if shouldGlow == self.forcesState.glowActive then return end

--- a/Display.lua
+++ b/Display.lua
@@ -589,12 +589,6 @@ function WarpDeplete:UpdateGlow()
   local percentBeforePull = self.forcesState.currentPercent
   local percentAfterPull = percentBeforePull + self.forcesState.pullPercent
   local shouldGlow = percentBeforePull < 1.0 and percentAfterPull >= 1.0
-  -- self:PrintDebug(
-  --   "Updating glow: " ..
-  --   "percentBeforePull(" .. tostring(percentBeforePull) .. ") " ..
-  --   "percentAfterPull(" .. tostring(percentAfterPull) .. ") " ..
-  --   "shouldGlow(" .. tostring(shouldGlow) .. ")"
-  -- )
 
   -- Already in the correct state
   if shouldGlow == self.forcesState.glowActive then return end
@@ -673,16 +667,16 @@ function WarpDeplete:UpdateObjectivesDisplay()
       if self.db.profile.timingsEnabled then
         local timeDiff = nil
 
-        if timingsDisplayStyle == "best" then
+        if timingsDisplayStyle == "bestDiff" then
           timeDiff = self:GetBestTimeDifference(i)
-        elseif timingsDisplayStyle == "last" then
+        elseif timingsDisplayStyle == "lastDiff" then
           timeDiff = self:GetLastTimeDifference(i)
         end
 
         if timeDiff ~= nil then
-          local timeDiffColor = self.db.profile.timingsWorseColor
+          local timeDiffColor = self.db.profile.timingsWorseTimeColor
           if timeDiff < 0 then
-            timeDiffColor = self.db.profile.timingsImprovedColor
+            timeDiffColor = self.db.profile.timingsImprovedTimeColor
           end
 
           local timeDiffStr = Util.formatTime(timeDiff, true)
@@ -705,6 +699,7 @@ end
 -- Expects level as number and affixes as an array of names and ids,
 -- e.g. {{ id = 0, name = "Tyrannical" }, { id = 1, name = "Bolstering" }}
 function WarpDeplete:SetKeyDetails(level, affixes, mapId)
+  self:PrintDebug("Setting key details map id: " .. mapId)
   self.keyDetailsState.level = level
   self.keyDetailsState.affixes = affixes
   self.keyDetailsState.mapId = mapId

--- a/Events.lua
+++ b/Events.lua
@@ -130,22 +130,21 @@ end
 function WarpDeplete:GetKeyInfo()
   self:PrintDebug("Getting key info")
 
-  local level, affixes = C_ChallengeMode.GetActiveKeystoneInfo()
+  local mapId = C_ChallengeMode.GetActiveChallengeMapID()
+  local level, affixIds = C_ChallengeMode.GetActiveKeystoneInfo()
 
-  local affixNames = {}
-  local affixIds = {}
-  for i, affixID in ipairs(affixes) do
-    local name = C_ChallengeMode.GetAffixInfo(affixID)
-    affixNames[i] = name
-    affixIds[i] = affixID
+  local affixes = {}
+  for i, id in ipairs(affixIds) do
+    local name = C_ChallengeMode.GetAffixInfo(id)
+    affixes[i] = { name = name, id = id }
   end
 
-  if level <= 0 or #affixNames <= 0 then
+  if level <= 0 or #affixes <= 0 then
     self:PrintDebug("No affixes or key level received")
     return false
   end
 
-  self:SetKeyDetails(level or 0, affixNames, affixIds)
+  self:SetKeyDetails(level or 0, affixes, mapId)
   return true
 end
 

--- a/Events.lua
+++ b/Events.lua
@@ -215,7 +215,6 @@ function WarpDeplete:UpdateForces()
   local currentCount = self:GetEnemyForcesCount()
   -- This mostly happens when we have already completed the dungeon
   if not currentCount then return end
-  self:PrintDebug("currentCount: " .. currentCount)
 
   if currentCount >= self.forcesState.totalCount and not self.forcesState.completed then
     -- If we just went above the total count (or matched it), we completed it just now
@@ -223,12 +222,16 @@ function WarpDeplete:UpdateForces()
     self.forcesState.completedTime = self.timerState.current
   end
 
-  self:SetForcesCurrent(currentCount)
+  -- When the dungeon is complete, we'll get 0 count back here,
+  -- so we don't set the current count in that case to preserve our
+  -- actual clear count
+  if currentCount > 0 or not self.challengeState.challengeCompleted then
+    self:SetForcesCurrent(currentCount)
+  end
 end
 
 function WarpDeplete:UpdateObjectives()
   if not self.challengeState.inChallenge then return end
-  self:PrintDebug("Updating objectives")
 
   local objectives = Util.copy(self.objectivesState)
   local changed = false
@@ -236,7 +239,6 @@ function WarpDeplete:UpdateObjectives()
   local stepCount = select(3, C_Scenario.GetStepInfo())
   for i = 1, stepCount - 1 do
     if not objectives[i] or not objectives[i].time then
-      self:PrintDebug("Updating objective " .. i)
       local completed = select(3, C_Scenario.GetCriteriaInfo(i))
 
       -- If it wasn't completed before and it is now, we've just completed

--- a/Events.lua
+++ b/Events.lua
@@ -175,7 +175,7 @@ function WarpDeplete:GetObjectivesInfo()
     if not name then break end
 
     name = gsub(name, " defeated", "")
-    self:PrintDebug("Got boss name for index " .. i .. ": " .. tostring(name))
+    self:PrintDebug("Got boss name for index " .. i .. ": " .. name)
     objectives[i] = { name = name, time = completed and 0 or nil }
   end
 

--- a/Options.lua
+++ b/Options.lua
@@ -446,11 +446,11 @@ function WarpDeplete:InitOptions()
           }
         }),
 
-        group(L["Timings"], true, {
+        group(L["Clear Time Recording"], true, {
           {
             type = "toggle",
-            name = L["Enable timings"],
-            desc = L["Enable recording of timestamps at which bosses have been killed"],
+            name = L["Enable clear time recording"],
+            desc = L["Enable recording of timestamps at which objectives have been cleared"],
             get = function(info) return WarpDeplete.db.profile.timingsEnabled end,
             set = function(info, value)
                WarpDeplete.db.profile.timingsEnabled = value
@@ -461,7 +461,7 @@ function WarpDeplete:InitOptions()
           {
             type = "toggle",
             name = L["Only record completed runs"],
-            desc = L["When active, timestamps are only recorded once the key has been finished"],
+            desc = L["When active, timestamps are only recorded once the challenge has been completed"],
             get = function(info) return WarpDeplete.db.profile.timingsOnlyCompleted end,
             set = function(info, value) WarpDeplete.db.profile.timingsOnlyCompleted = value end,
             width = 2

--- a/Options.lua
+++ b/Options.lua
@@ -462,10 +462,32 @@ function WarpDeplete:InitOptions()
             type = "toggle",
             name = L["Only record completed runs"],
             desc = L["When active, timestamps are only recorded once the challenge has been completed"],
+            hidden = function() return not WarpDeplete.db.profile.timingsEnabled end,
             get = function(info) return WarpDeplete.db.profile.timingsOnlyCompleted end,
             set = function(info, value) WarpDeplete.db.profile.timingsOnlyCompleted = value end,
             width = 2
-          }
+          },
+
+          lineBreak(),
+
+          {
+            type = "select",
+            name = L["Objectives time difference"],
+            desc = L["How to display timing differences in the objective display"],
+            sorting = { "hidden", "bestDiff", "lastDiff" },
+            values = {
+              ["hidden"] = L["Hidden"],
+              ["bestDiff"] = L["Difference to best kill time"],
+              ["lastDiff"] = L["Difference to last kill time"]
+            },
+            hidden = function() return not WarpDeplete.db.profile.timingsEnabled end,
+            get = function(info) return WarpDeplete.db.profile.timingsDisplayStyle end,
+            set = function(info, value)
+              WarpDeplete.db.profile.timingsDisplayStyle = value
+              self:UpdateLayout()
+            end,
+            width = 3 / 2
+          },
         })
       }, { order = 3 }),
 
@@ -616,35 +638,13 @@ function WarpDeplete:InitOptions()
           font(L["Objectives font"], "objectivesFont", "UpdateLayout", { width = 3 / 2 }),
           fontFlags(L["Objectives font flags"], "objectivesFontFlags", "UpdateLayout", { width = 3 / 2 }),
           range(L["Objectives font size"], "objectivesFontSize", "UpdateLayout", { width = 3 / 2 }),
-          {
-            type = "select",
-            name = L["Objectives time difference"],
-            desc = L["How to display timing differences in the objective display"],
-            sorting = {
-              "hidden",
-              "bestDiff",
-              "lastDiff"
-            },
-            values = {
-              ["hidden"] = L["Hidden"],
-              ["bestDiff"] = L["Difference to best kill time"],
-              ["lastDiff"] = L["Difference to last kill time"]
-            },
-            hidden = function() return not WarpDeplete.db.profile.timingsEnabled end,
-            get = function(info) return WarpDeplete.db.profile.timingsDisplayStyle end,
-            set = function(info, value)
-              WarpDeplete.db.profile.timingsDisplayStyle = value
-              self:UpdateLayout()
-            end,
-            width = 3 / 2
-          },
           color(L["Objectives color"], "objectivesColor", "UpdateLayout"),
           color(L["Completed objective color"], "completedObjectivesColor", "UpdateLayout"),
-          color(L["New best objective clear time"], "timingsImprovedTimeColor", "UpdateLayout", {
-            desc = L["The color to use when you've set a new best objective clear time"]
+          color(L["Faster objective clear time"], "timingsImprovedTimeColor", "UpdateLayout", {
+            desc = L["The color to use when you've set a new best objective clear time or improved your last time"]
           }),
           color(L["Slower objective clear time"], "timingsWorseTimeColor", "UpdateLayout", {
-            desc = L["The color to use for objective clear times slower than your best time"]
+            desc = L["The color to use for objective clear times slower than your best or last time"]
           }),
         }),
       }, { order = 4 }),

--- a/Options.lua
+++ b/Options.lua
@@ -700,7 +700,41 @@ function WarpDeplete:InitOptions()
       step = 1,
       get = function(info) return WarpDeplete.forcesState.currentCount end,
       set = function(info, value) WarpDeplete:SetForcesCurrent(value) end
-    }
+    },
+
+    lineBreak(),
+
+    {
+      type = "execute",
+      name = "Print Timings DB",
+      func = function()
+        self:PrintDebug("Timings:")
+        for mapId, levels in pairs(self.db.char.timings) do
+          for level, affixIds in pairs(levels) do
+            for affixId, objectives in pairs(affixIds) do
+              for objective, timing in pairs(objectives) do
+                self:PrintDebug(
+                  "Timing: mapId(" .. mapId .. ") " ..
+                  "level(" .. level .. ") " ..
+                  "affixId(" .. affixId .. ") " ..
+                  "objective(" .. objective .. ") " ..
+                  "best(" .. timing.best .. ") " ..
+                  "last(" .. timing.last .. ")"
+                )
+              end
+            end
+          end
+        end
+
+        self:PrintDebug("Current Timings mapId(" .. self.db.char.currentRunTimings.mapId .. "):")
+        for objective, timing in pairs(self.db.char.currentRunTimings.objectives) do
+          self:PrintDebug("objective " .. objective)
+          for k, v in pairs(timing) do
+            self:PrintDebug("-- " .. k .. ": " .. tostring(v))
+          end
+        end
+      end
+    },
   })
 
   options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)

--- a/Timings.lua
+++ b/Timings.lua
@@ -26,8 +26,8 @@ function WarpDeplete:GetCurrentRunTimings(objectiveIndex)
 end
 
 function WarpDeplete:GetBestTimeDifference(objectiveIndex)
-  local objectiveTimings = self:GetObjectiveTimings(objectiveIndex)
-  if objectiveTimings == nil or objectiveTimings.bestUpdated == false then
+  local objectiveTimings = self:GetCurrentRunTimings(objectiveIndex)
+  if objectiveTimings == nil then
     return nil
   end
 
@@ -37,11 +37,11 @@ function WarpDeplete:GetBestTimeDifference(objectiveIndex)
     return nil
   end
 
-  return objectiveTimings.newBest - objectiveTimings.lastBest
+  return objectiveTimings.newTime - objectiveTimings.lastBest
 end
 
 function WarpDeplete:GetLastTimeDifference(objectiveIndex)
-  local objectiveTimings = self:GetObjectiveTimings(objectiveIndex)
+  local objectiveTimings = self:GetCurrentRunTimings(objectiveIndex)
   if objectiveTimings == nil or objectiveTimings.lastTime == nil then
     return nil
   end
@@ -132,7 +132,7 @@ function WarpDeplete:SetTiming(objectiveIndex, newTime)
     lastTime = prevTiming.last,
     newTime = newTime,
     bestUpdated = false,
-    prevBest = prevTiming.best,
+    lastBest = prevTiming.best,
   }
 
   if prevTiming.best == nil or newTime < prevTiming.best then
@@ -146,7 +146,6 @@ function WarpDeplete:SetTiming(objectiveIndex, newTime)
     -- In that case, we don't want to show something incorrect
     -- to the user.
     currentTimings.bestUpdated = true
-    currentTimings.newBest = newTime
     newTiming.best = newTiming.last
   end
 

--- a/Timings.lua
+++ b/Timings.lua
@@ -6,13 +6,13 @@ function WarpDeplete:UpdateTimings()
     return
   end
 
-  if not self.challengeState.challengeCompleted and not self.db.profile.timingsOnlyCompleted then
+  if not self.challengeState.challengeCompleted and
+    not self.db.profile.timingsOnlyCompleted then
     self:PrintDebug("Skipping timings update: challenge not completed")
     return
   end
 
   self:PrintDebug("Updating timings")
-  local objectives = Util.copy(self.objectivesState)
   local timings = self:GetTimingsForCurrentInstance()
 
   if timings == nil then
@@ -32,8 +32,8 @@ function WarpDeplete:UpdateTimings()
     timings.last = last
   end
 
-  for i = 1, #objectives do
-    local boss = objectives[i]
+  for i = 1, #self.objectivesState do
+    local boss = self.objectivesState[i]
     if boss.time ~= nil then
       self:PrintDebug("Setting last time for " .. boss.name .. " (" .. i .. ")")
       last[i] = boss.time
@@ -76,13 +76,15 @@ end
 
 function WarpDeplete:GetTimingsForCurrentInstance(strict)
   local level = self.keyDetailsState.level
-  local mapId = select(8, GetInstanceInfo())
-  local firstAffix = self.keyDetailsState.affixIds[1]
-  if mapId == nil or level == nil or firstAffix == nil then
+  local mapId = self.keyDetailsState.mapId
+  local affixes = self.keyDetailsState.affixes or {}
+  local firstAffixId = affixes.id
+
+  if mapId == nil or level == nil or firstAffixId == nil then
     return nil
   end
 
-  return self:GetTimings(mapId, level, firstAffix, strict)
+  return self:GetTimings(mapId, level, firstAffixId, strict)
 end
 
 function WarpDeplete:GetTimings(mapId, keystoneLevel, firstAffixId, strict)

--- a/Timings.lua
+++ b/Timings.lua
@@ -4,9 +4,9 @@ function WarpDeplete:GetCurrentRunTimings(objectiveIndex)
   local level = self.keyDetailsState.level
   local mapId = self.keyDetailsState.mapId
   local affixes = self.keyDetailsState.affixes or {}
-  local firstAffixId = affixes.id
+  local firstAffix = affixes[1] or {}
 
-  if mapId == nil or level == nil or firstAffixId == nil then
+  if mapId == nil or level == nil or firstAffix.id == nil then
     self:PrintDebug("Failed to get current run timings due to missing keyDetailsState fields")
     return nil
   end
@@ -71,7 +71,7 @@ function WarpDeplete:SetTiming(objectiveIndex, newTime)
   end
 
   if not self.challengeState.challengeCompleted and
-    not self.db.profile.timingsOnlyCompleted then
+    self.db.profile.timingsOnlyCompleted then
     self:PrintDebug("Skipping timings update: challenge not completed")
     return
   end
@@ -81,9 +81,9 @@ function WarpDeplete:SetTiming(objectiveIndex, newTime)
   local level = self.keyDetailsState.level
   local mapId = self.keyDetailsState.mapId
   local affixes = self.keyDetailsState.affixes or {}
-  local firstAffixId = affixes.id
+  local firstAffix = affixes[1] or {}
 
-  if mapId == nil or level == nil or firstAffixId == nil then
+  if mapId == nil or level == nil or firstAffix.id == nil then
     self:PrintDebug("Failed to set new timing due to missing keyDetailsState fields")
     return
   end
@@ -92,7 +92,7 @@ function WarpDeplete:SetTiming(objectiveIndex, newTime)
     "Setting new timing: " ..
     "mapId(" .. mapId .. ") " ..
     "level(" .. level .. ") " ..
-    "firstAffixId(" .. firstAffixId .. ") " ..
+    "firstAffix.id(" .. firstAffix.id .. ") " ..
     "objectiveIndex(" .. objectiveIndex .. ") " ..
     "newTime(" .. newTime .. ")"
   )
@@ -111,16 +111,16 @@ function WarpDeplete:SetTiming(objectiveIndex, newTime)
     self.db.char.timings[mapId][level] = {}
   end
 
-  if self.db.char.timings[mapId][level][firstAffixId] == nil then
-    self.db.char.timings[mapId][level][firstAffixId] = {}
+  if self.db.char.timings[mapId][level][firstAffix.id] == nil then
+    self.db.char.timings[mapId][level][firstAffix.id] = {}
   end
 
-  if self.db.char.timings[mapId][level][firstAffixId][objectiveIndex] == nil then
-    self.db.char.timings[mapId][level][firstAffixId][objectiveIndex] = {}
+  if self.db.char.timings[mapId][level][firstAffix.id][objectiveIndex] == nil then
+    self.db.char.timings[mapId][level][firstAffix.id][objectiveIndex] = {}
   end
 
   local prevTiming = Util.copy(
-    self.db.char.timings[mapId][level][firstAffixId][objectiveIndex]
+    self.db.char.timings[mapId][level][firstAffix.id][objectiveIndex]
   )
 
   local newTiming = {
@@ -150,7 +150,7 @@ function WarpDeplete:SetTiming(objectiveIndex, newTime)
     newTiming.best = newTiming.last
   end
 
-  self.db.char.timings[mapId][level][firstAffixId][objectiveIndex] = newTiming
+  self.db.char.timings[mapId][level][firstAffix.id][objectiveIndex] = newTiming
 
   -- Persist the changes we just saved for the current map id.
   if self.db.char.currentRunTimings.mapId == nil or

--- a/Util.lua
+++ b/Util.lua
@@ -198,20 +198,6 @@ function Util.calcForcesPercent(forcesPercent, unclampForcesPercent)
   return math.min(forcesPercent, 100.0)  
 end
 
-function Util.joinStrings(strings, delim)
-  local result = ""
-
-  for i, s in ipairs(strings) do
-    result = result .. s
-
-    if i < #strings then
-      result = result .. delim
-    end
-  end
-
-  return result
-end
-
 function Util.showAlert(key, message, okMessage)
   StaticPopupDialogs[key] = {
     text = message,

--- a/Util.lua
+++ b/Util.lua
@@ -211,32 +211,6 @@ function Util.showAlert(key, message, okMessage)
   StaticPopup_Show(key)
 end
 
-Util.MapIDToInstanceID = {
-  [1677] = 1188, -- De Other Side
-  [1678] = 1188, -- De Other Side
-  [1679] = 1188, -- De Other Side
-  [1680] = 1188, -- De Other Side
-  [1669] = 1184, -- Mists of Tirna Scithe
-  [1697] = 1183, -- Plaguefall
-  [1675] = 1189, -- Sanguine Depths
-  [1676] = 1189, -- Sanguine Depths
-  [1692] = 1186, -- Spires of Ascension
-  [1693] = 1186, -- Spires of Ascension
-  [1694] = 1186, -- Spires of Ascension
-  [1695] = 1186, -- Spires of Ascension
-  [1666] = 1182, -- The Necrotic Wake
-  [1667] = 1182, -- The Necrotic Wake
-  [1668] = 1182, -- The Necrotic Wake
-  [1683] = 1187, -- Theater of Pain
-  [1684] = 1187, -- Theater of Pain
-  [1685] = 1187, -- Theater of Pain
-  [1686] = 1187, -- Theater of Pain
-  [1687] = 1187, -- Theater of Pain
-  [1663] = 1185, -- Halls of Atonement
-  [1664] = 1185, -- Halls of Atonement
-  [1665] = 1185, -- Halls of Atonement
-}
-
 function WarpDeplete:PrintDebug(str)
   if not self.db.global.DEBUG then return end
   self:Print("|cFF479AEDDEBUG|r " .. str)


### PR DESCRIPTION
I'm pretty confident that this should work now, but I haven't had the time to do too much playtesting, so I'd appreciate if you could also run a few dungeons on this branch and tell me if there are any issues. I'd like to avoid pushing out a new version too fast, since we've already done so once :-P

The only feature I haven't ported over from the previous version is the ability to also display timings if only a key level lower or higher was recorded. What exactly did you have in mind for that?