### PR TITLE
Properly show force % above 100%

### DIFF
--- a/DB.lua
+++ b/DB.lua
@@ -1,6 +1,6 @@
 local defaults = {
   global = {
-    DEBUG = false,
+    DEBUG = true,
     mdtAlertShown = false,
   },
 

--- a/Display.lua
+++ b/Display.lua
@@ -532,7 +532,7 @@ function WarpDeplete:SetForcesTotal(totalCount)
 
   self.forcesState.completed = false
   self.forcesState.completedTime = 0
-
+  self:PrintDebug("SetForcesTotal Updated")
   self:UpdateForcesDisplay()
 end
 
@@ -569,19 +569,19 @@ function WarpDeplete:SetForcesCurrent(currentCount)
 
   --if currentPercent > 1.0 then currentPercent = 1.0 end
   self.forcesState.currentPercent = currentPercent
-
+  self:PrintDebug("UpdateForcesDispaly ran - self currentCount: ".. self.forcesState.currentCount)
   self:UpdateForcesDisplay()
 end
 
 function WarpDeplete:UpdateForcesDisplay()
-  if self.challengeState.challengeCompleted then
-    self.forcesState.currentPercent = currentPercent
+  -- if self.challengeState.challengeCompleted then
+  --   self.forcesState.currentPercent = currentPercent
 
-    -- if self.forcesState.currentCount < self.forcesState.totalCount then
-    --   self.forcesState.currentCount = self.forcesState.totalCount
-    -- end
-  end
-
+  --    if self.forcesState.currentCount < self.forcesState.totalCount then
+  --      self.forcesState.currentCount = self.forcesState.totalCount
+  --    end
+  -- end
+  self:PrintDebug("UpdatedForcesDisplay 2.0 - self currentCount: ".. self.forcesState.currentCount)
   if self.forcesState.currentPercent < 1.0 then
     -- clamp pull progress so that the bar won't exceed 100%
     local pullPercent = self.forcesState.pullPercent
@@ -613,6 +613,7 @@ function WarpDeplete:UpdateForcesDisplay()
     )
   )
   self:UpdateGlow()
+  self:PrintDebug("UpdatedForcesDisplay 3.0 - self currentCount: ".. self.forcesState.currentCount)
 end
 
 function WarpDeplete:UpdateGlowAppearance()

--- a/Display.lua
+++ b/Display.lua
@@ -527,7 +527,7 @@ function WarpDeplete:SetForcesTotal(totalCount)
   self.forcesState.pullPercent = totalCount > 0 and self.forcesState.pullCount / totalCount or 0
 
   local currentPercent = totalCount > 0 and self.forcesState.currentCount / totalCount or 0
-  if currentPercent > 1.0 then currentPercent = 1.0 end
+  --if currentPercent > 1.0 then currentPercent = 1.0 end
   self.forcesState.currentPercent = currentPercent
 
   self.forcesState.completed = false
@@ -567,7 +567,7 @@ function WarpDeplete:SetForcesCurrent(currentCount)
   local currentPercent = self.forcesState.totalCount > 0
     and self.forcesState.currentCount / self.forcesState.totalCount or 0
 
-  if currentPercent > 1.0 then currentPercent = 1.0 end
+  --if currentPercent > 1.0 then currentPercent = 1.0 end
   self.forcesState.currentPercent = currentPercent
 
   self:UpdateForcesDisplay()
@@ -575,11 +575,11 @@ end
 
 function WarpDeplete:UpdateForcesDisplay()
   if self.challengeState.challengeCompleted then
-    self.forcesState.currentPercent = 1.0
+    self.forcesState.currentPercent = currentPercent
 
-    if self.forcesState.currentCount < self.forcesState.totalCount then
-      self.forcesState.currentCount = self.forcesState.totalCount
-    end
+    -- if self.forcesState.currentCount < self.forcesState.totalCount then
+    --   self.forcesState.currentCount = self.forcesState.totalCount
+    -- end
   end
 
   if self.forcesState.currentPercent < 1.0 then

--- a/Util.lua
+++ b/Util.lua
@@ -206,7 +206,7 @@ function Util.calcForcesPercent(forcesPercent, unclampForcesPercent)
   if unclampForcesPercent then
     return forcesPercent
   end
-  return math.min(forcesPercent, 100.0)  
+  return math.min(forcesPercent, 200.0)  
 end
 
 function Util.joinStrings(strings, delim)

--- a/Util.lua
+++ b/Util.lua
@@ -206,7 +206,7 @@ function Util.calcForcesPercent(forcesPercent, unclampForcesPercent)
   if unclampForcesPercent then
     return forcesPercent
   end
-  return math.min(forcesPercent, 200.0)  
+  return math.min(forcesPercent, 100.0)  
 end
 
 function Util.joinStrings(strings, delim)


### PR DESCRIPTION
Tied to "Show forces percent above 100%" if checked, properly calculates the percentage and count of forces above 100%.
Otherwise, will clamp to 100%.

Previously, this button didn't really do anything. Hasn't done so in a while as far as i could tell. The behavior it has now makes sense based on what the button says.