### PR TITLE
More aggresively hide the ObjectiveTrackerFrame

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -77,6 +77,12 @@ function WarpDeplete:OnInitialize()
   frames.bars = CreateFrame("Frame", "WarpDepleteBars", frames.root)
   frames.deathsTooltip = CreateFrame("Frame", "WarpDepleteDeathsTooltip", frames.root)
 
+  -- We use an empty frame to which we parent the blizzard objective tracker.
+  -- This can then be hidden and not be affected by blizzard unhiding the
+  -- objective tracker itself.
+  frames.hiddenObjectiveTrackerParent = CreateFrame("frame")
+  frames.hiddenObjectiveTrackerParent:Hide()
+
   self.frames = frames
 end
 
@@ -196,9 +202,6 @@ function WarpDeplete:DisableDemoMode()
   self:ResetState()
 end
 
-local hiddenParent = CreateFrame('frame')
-hiddenParent:Hide()
-local oldParent
 function WarpDeplete:ShowBlizzardObjectiveTracker()
   -- As SylingTracker replaces the blizzard objective tracker in hiding
   -- it, we prevent WarpDeplete to reshown the tracker.
@@ -206,14 +209,12 @@ function WarpDeplete:ShowBlizzardObjectiveTracker()
     return
   end
 
-  ObjectiveTrackerFrame:SetParent(oldParent or UIParent)
+  ObjectiveTrackerFrame:SetParent(self.originalObjectiveTrackerParent or UIParent)
 end
 
 function WarpDeplete:HideBlizzardObjectiveTracker()
-  if ObjectiveTrackerFrame:IsVisible() then
-    oldParent = ObjectiveTrackerFrame:GetParent()
-    ObjectiveTrackerFrame:SetParent(hiddenParent)
-  end
+  self.originalObjectiveTrackerParent = ObjectiveTrackerFrame:GetParent()
+  ObjectiveTrackerFrame:SetParent(self.frames.hiddenObjectiveTrackerParent)
 end
 
 function WarpDeplete:ShowExternals()

--- a/Core.lua
+++ b/Core.lua
@@ -196,6 +196,9 @@ function WarpDeplete:DisableDemoMode()
   self:ResetState()
 end
 
+local hiddenParent = CreateFrame('frame')
+hiddenParent:Hide()
+local oldParent
 function WarpDeplete:ShowBlizzardObjectiveTracker()
   -- As SylingTracker replaces the blizzard objective tracker in hiding
   -- it, we prevent WarpDeplete to reshown the tracker.
@@ -203,12 +206,13 @@ function WarpDeplete:ShowBlizzardObjectiveTracker()
     return
   end
 
-  ObjectiveTrackerFrame:Show()
+  ObjectiveTrackerFrame:SetParent(oldParent or UIParent)
 end
 
 function WarpDeplete:HideBlizzardObjectiveTracker()
   if ObjectiveTrackerFrame:IsVisible() then
-    ObjectiveTrackerFrame:Hide()
+    oldParent = ObjectiveTrackerFrame:GetParent()
+    ObjectiveTrackerFrame:SetParent(hiddenParent)
   end
 end
 

--- a/Events.lua
+++ b/Events.lua
@@ -450,14 +450,6 @@ function WarpDeplete:OnTimerTick(elapsed)
   local current = GetTime() + self.timerState.startOffset - self.timerState.startTime + deathPenalty
 
   self:SetTimerCurrent(current)
-
-  -- FIXME(happens): Blizzard seems to randomly re-show the objective tracker on
-  -- a lot of events, and even re-hiding it on CLEU events doesn't seem to cover
-  -- all cases.
-  -- The best solution would be to somehow hook into the actual function that
-  -- shows the objective tracker or some event that fires when it's unhidden, but
-  -- that currently doesn't seem to be possible.
-  self:HideBlizzardObjectiveTracker()
 end
 
 function WarpDeplete:OnCheckChallengeMode(ev)

--- a/Events.lua
+++ b/Events.lua
@@ -479,10 +479,6 @@ function WarpDeplete:OnPlayerDead(ev)
   -- good method for deduping though.
   -- self:BroadcastDeath()
   self:ResetCurrentPull()
-
-  -- Blizzard re-shows the objective tracker every time the player
-  -- dies, so we need to re-hide it
-  self:HideBlizzardObjectiveTracker()
 end
 
 function WarpDeplete:OnChallengeModeReset(ev)
@@ -551,7 +547,6 @@ end
 function WarpDeplete:OnResetCurrentPull(ev)
   self:PrintDebugEvent(ev)
   self:ResetCurrentPull()
-  self:HideBlizzardObjectiveTracker()
 end
 
 function WarpDeplete:OnThreatListUpdate(ev, unit)


### PR DESCRIPTION
now blizzard can :Show/:Hide the objective tracker as much as they like. once it's hidden, it stays hidden until you decide it should no longer be hidden