### PR TITLE
fix: Use quantityString instead of estimating forces count

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -36,8 +36,6 @@ WarpDeplete.defaultForcesState = {
 
   completed = false,
   completedTime = 0,
-
-  hasMDTTotalCount = false,
 }
 
 WarpDeplete.defaultTimerState = {
@@ -117,7 +115,7 @@ function WarpDeplete:ShowMDTAlert()
   Util.showAlert(
     "MDT_NOT_FOUND",
     L["Mythic Dungeon Tools (MDT) is not installed."].."\n\n" ..
-    L["WarpDeplete will not display mob counts or count for the current pull."]
+    L["WarpDeplete will not display the count for your current pull."]
     .. " \n\n" .. L["Install MDT to enable this functionality."])
 end
 
@@ -128,13 +126,13 @@ function WarpDeplete:UpdateDemoModeForces()
   if not self.challengeState.demoModeActive then return end
 
   if self.db.profile.showForcesGlow and self.db.profile.demoForcesGlow then
-    self:SetForcesPercent(92)
+    self:SetForcesCurrent(92)
     self:SetForcesPull(8)
   elseif self.db.profile.unclampForcesPercent then
-    self:SetForcesPercent(101)
+    self:SetForcesCurrent(101)
     self:SetForcesPull(3.4)
   else
-    self:SetForcesPercent(34)
+    self:SetForcesCurrent(34)
     self:SetForcesPull(7)
   end
 end

--- a/Display.lua
+++ b/Display.lua
@@ -523,64 +523,26 @@ function WarpDeplete:UpdateTimerDisplay()
 end
 
 -- Expects direct forces value
--- NOTE(happens): This is currently unused as Blizzard does not offer
--- direct forces values anymore, only percentages.
--- function WarpDeplete:SetForcesTotal(totalCount)
---   self.forcesState.totalCount = totalCount
---   self.forcesState.pullPercent = totalCount > 0 and self.forcesState.pullCount / totalCount or 0
---
---   local currentPercent = totalCount > 0 and self.forcesState.currentCount / totalCount or 0
---   if currentPercent > 1.0 then currentPercent = 1.0 end
---   self.forcesState.currentPercent = currentPercent
---
---   self.forcesState.completed = false
---   self.forcesState.completedTime = 0
---
---   self:UpdateForcesDisplay()
--- end
+function WarpDeplete:SetForcesTotal(totalCount)
+  self.forcesState.totalCount = totalCount
+  self.forcesState.pullPercent = totalCount > 0 and self.forcesState.pullCount / totalCount or 0
+
+  local currentPercent = totalCount > 0 and self.forcesState.currentCount / totalCount or 0
+  if currentPercent > 1.0 then currentPercent = 1.0 end
+  self.forcesState.currentPercent = currentPercent
+
+  self.forcesState.completed = false
+  self.forcesState.completedTime = 0
+
+  self:UpdateForcesDisplay()
+end
 
 -- Expects direct forces value
--- NOTE(happens): This is currently unused as Blizzard does not offer
--- direct forces values anymore, only percentages.
--- function WarpDeplete:SetForcesCurrent(currentCount)
---   if self.forcesState.currentCount < self.forcesState.totalCount and
---     currentCount >= self.forcesState.totalCount
---   then
---     self.forcesState.completed = true
---     self.forcesState.completedTime = self.timerState.current
---   end
---
---   -- The current count can only ever go up. The only place where it should
---   -- ever decrease is when it's reset in ResetState.
---   -- It seems that the API reports a current count of 0 when the dungeon is
---   -- finished, but possibly right before the challengeCompleted flag is triggered.
---   -- So, to make sure we don't reset the bar to 0 in that case, we only allow
---   -- the count to go up here.
---   if currentCount >= self.forcesState.currentCount then
---     self.forcesState.currentCount = currentCount
---   end
---
---   local currentPercent = self.forcesState.totalCount > 0
---     and self.forcesState.currentCount / self.forcesState.totalCount or 0
---
---   if currentPercent > 1.0 then currentPercent = 1.0 end
---   self.forcesState.currentPercent = currentPercent
---
---   self:UpdateForcesDisplay()
--- end
-
--- Expects a number between 0 and 100
-function WarpDeplete:SetForcesPercent(currentPercent)
-  -- We want the percentage in a scale from 0.0 to 1.0
-  local scaledPercent = currentPercent / 100
-
-  self:PrintDebug("Setting forces percent to " ..
-    currentPercent .. " (" .. scaledPercent .. ") " ..
-    "current: " .. self.forcesState.currentPercent
-  )
-
+function WarpDeplete:SetForcesCurrent(currentCount)
   -- Check if we just completed the dungeon
-  if self.forcesState.currentPercent < 1.0 and scaledPercent >= 1.0 then
+  if self.forcesState.currentCount < self.forcesState.totalCount and
+    currentCount >= self.forcesState.totalCount
+  then
     self.forcesState.completed = true
     self.forcesState.completedTime = self.timerState.current
   end
@@ -591,23 +553,15 @@ function WarpDeplete:SetForcesPercent(currentPercent)
   -- finished, but possibly right before the challengeCompleted flag is triggered.
   -- So, to make sure we don't reset the bar to 0 in that case, we only allow
   -- the count to go up here.
-  if scaledPercent >= self.forcesState.currentPercent then
-    self.forcesState.currentPercent = scaledPercent
+  if currentCount >= self.forcesState.currentCount then
+    self.forcesState.currentCount = currentCount
   end
 
-  if self.forcesState.hasMDTTotalCount then
-    -- If we have count information from MDT, we use that to calculate the
-    -- current count.
-    local estimatedCount = self.forcesState.totalCount * scaledPercent
-    self.forcesState.currentCount = math.floor(estimatedCount)
-    if self.forcesState.currentCount >= self.forcesState.totalCount then
-      self.forcesState.currentCount = self.forcesState.totalCount
-    end
-  else
-    -- If we don't have any count information, we just use the percentage as
-    -- the count, as 100 as the max count is set as default from the start.
-    self.forcesState.currentCount = currentPercent
-  end
+  local currentPercent = self.forcesState.totalCount > 0
+    and self.forcesState.currentCount / self.forcesState.totalCount or 0
+
+  if currentPercent > 1.0 then currentPercent = 1.0 end
+  self.forcesState.currentPercent = currentPercent
 
   self:UpdateForcesDisplay()
 end

--- a/Options.lua
+++ b/Options.lua
@@ -681,15 +681,15 @@ function WarpDeplete:InitOptions()
       set = function(info, value) WarpDeplete:SetTimerRemaining(value * 60) end
     },
 
-    -- {
-    --   type = "range",
-    --   name = L["Forces total"],
-    --   min = 1,
-    --   max = 500,
-    --   step = 1,
-    --   get = function(info) return WarpDeplete.forcesState.totalCount end,
-    --   set = function(info, value) WarpDeplete:SetForcesTotal(value) end
-    -- },
+    {
+      type = "range",
+      name = L["Forces total"],
+      min = 1,
+      max = 500,
+      step = 1,
+      get = function(info) return WarpDeplete.forcesState.totalCount end,
+      set = function(info, value) WarpDeplete:SetForcesTotal(value) end
+    },
 
     {
       type = "range",
@@ -701,15 +701,15 @@ function WarpDeplete:InitOptions()
       set = function(info, value) WarpDeplete:SetForcesPull(value) end
     },
 
-    -- {
-    --   type = "range",
-    --   name = L["Forces current"],
-    --   min = 1,
-    --   max = 500,
-    --   step = 1,
-    --   get = function(info) return WarpDeplete.forcesState.currentCount end,
-    --   set = function(info, value) WarpDeplete:SetForcesCurrent(value) end
-    -- }
+    {
+      type = "range",
+      name = L["Forces current"],
+      min = 1,
+      max = 500,
+      step = 1,
+      get = function(info) return WarpDeplete.forcesState.currentCount end,
+      set = function(info, value) WarpDeplete:SetForcesCurrent(value) end
+    }
   })
 
   options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)


### PR DESCRIPTION
This uses the new quantityString field instead of estimating the forces count using total counts from MDT and the percentage from the API.