### PR TITLE
C_ChallengeMode.GetCompletionInfo was set to deprecated in 11.0.5

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -319,7 +319,8 @@ function WarpDeplete:CompleteChallenge()
 	self:ResetCurrentPull()
 
 	self.state.challengeCompleted = true
-	local _, _, timeMs, onTime = C_ChallengeMode.GetCompletionInfo()
+	local info = C_ChallengeMode.GetChallengeCompletionInfo()
+	local timeMs, onTime = info.time, info.onTime
 	local time = math.ceil(timeMs / 1000)
 
 	self.state.completedOnTime = onTime


### PR DESCRIPTION
Might as well move over to the new function, right? https://www.townlong-yak.com/framexml/live/Blizzard_Deprecated/Deprecated_11_0_5.lua