### PR TITLE
fix: Unconditionally refresh boss names from encounter journal

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -195,7 +195,10 @@ function WarpDeplete:ResetState()
 end
 
 function WarpDeplete:CheckForChallengeMode()
-	local inChallenge = C_ChallengeMode.IsChallengeModeActive()
+	-- C_ChallengeMode.IsChallengeModeActive returns false after
+	-- the key has been completed, so this is more reliable
+	local _, type, difficulty = GetInstanceInfo()
+	local inChallenge = difficulty == 8 and type == "party"
 	if self.state.inChallenge == inChallenge then
 		return
 	end

--- a/Core.lua
+++ b/Core.lua
@@ -195,8 +195,7 @@ function WarpDeplete:ResetState()
 end
 
 function WarpDeplete:CheckForChallengeMode()
-	local _, type, difficulty = GetInstanceInfo()
-	local inChallenge = difficulty == 8 and type == "party"
+	local inChallenge = C_ChallengeMode.IsChallengeModeActive()
 	if self.state.inChallenge == inChallenge then
 		return
 	end
@@ -226,7 +225,6 @@ function WarpDeplete:EnableChallengeMode()
 
 	self:LoadKeyDetails()
 	self:LoadDeathCount()
-	self:LoadEJBossNames()
 	self:UpdateObjectives()
 
 	self:Show()

--- a/Core.lua
+++ b/Core.lua
@@ -92,7 +92,7 @@ function WarpDeplete:EnableDemoMode()
 	self.state.objectives = objectives
 	self:RenderObjectives()
 
-	self:SetKeyDetails(30, 15, { L["Ascendance"], L["Tyrannical"], L["Fortified"], L["Peril"] }, { 9, 7, 123, 152 })
+	self:SetKeyDetails(30, true, { L["Ascendance"], L["Tyrannical"], L["Fortified"], L["Peril"] }, { 9, 7, 123, 152 }, 1)
 
 	self:SetTimeLimit(35 * 60)
 	self:SetTimer(20 * 60)
@@ -208,43 +208,4 @@ function WarpDeplete:CheckForChallengeMode()
 	else
 		self:DisableChallengeMode()
 	end
-end
-
-function WarpDeplete:EnableChallengeMode()
-	if self.state.inChallenge then
-		self:PrintDebug("Enabling challenge mode while in challenge")
-	end
-
-	if self.state.demoModeActive then
-		self:Print(L["Disabling demo mode because a challenge has started."])
-		self:DisableDemoMode()
-	end
-
-	self:PrintDebug("Starting challenge mode")
-	self:ResetState()
-	self:RegisterChallengeEvents()
-
-	self.state.inChallenge = true
-
-	self:LoadKeyDetails()
-	self:LoadDeathCount()
-
-	self.state.ejObjectiveNames = self:GetEJObjectiveNames()
-	self:UpdateObjectives()
-
-	self:Show()
-	self:StartTimerLoop()
-end
-
-function WarpDeplete:DisableChallengeMode()
-	if self.isShown then
-		self:Hide()
-	end
-
-	if not self.state.inChallenge then
-		return
-	end
-
-	self:ResetState()
-	self:UnregisterChallengeEvents()
 end

--- a/Core.lua
+++ b/Core.lua
@@ -225,6 +225,8 @@ function WarpDeplete:EnableChallengeMode()
 
 	self:LoadKeyDetails()
 	self:LoadDeathCount()
+
+	self.state.ejObjectiveNames = self:GetEJObjectiveNames()
 	self:UpdateObjectives()
 
 	self:Show()

--- a/Options.lua
+++ b/Options.lua
@@ -847,6 +847,20 @@ function WarpDeplete:InitOptions()
 			end,
 			width = 3 / 2,
 		},
+		{
+			type = "toggle",
+			name = L["Challenger's Peril"],
+			get = function(_)
+				return WarpDeplete.state.hasChallengersPeril
+			end,
+			set = function(_, value)
+				WarpDeplete.state.hasChallengersPeril = value
+				self:SetTimeLimit(self.state.timeLimit)
+				self:RenderLayout()
+				self:RenderTimer()
+			end,
+			width = 3 / 2,
+		},
 	})
 
 	options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db)

--- a/State.lua
+++ b/State.lua
@@ -1,4 +1,5 @@
 local Util = WarpDeplete.Util
+local L = WarpDeplete.L
 
 ---@class WarpDepleteObjective
 ---@field name? string
@@ -20,6 +21,10 @@ WarpDeplete.defaultState = {
 	timerStarted = false,
 	timer = 0,
 	timeLimit = 0,
+	-- Time limits for +1, +2 and +3 in order. The first element
+	-- will always be equal to timeLimit and is only in here for
+	-- ease of access.
+	timeLimits = {},
 
 	deathCount = 0,
 	deathDetails = {},
@@ -43,6 +48,7 @@ WarpDeplete.defaultState = {
 	deathPenalty = 0,
 	affixes = {}, ---@type string[]
 	affixIds = {}, ---@type integer[]
+	hasChallengersPeril = false,
 	mapId = nil, ---@type integer|nil
 }
 
@@ -103,17 +109,36 @@ end
 
 function WarpDeplete:SetTimeLimit(timeLimit)
 	self.state.timeLimit = timeLimit
+
+	if self.state.hasChallengersPeril then
+		local limitWithoutPerilBonus = timeLimit - 90
+		self.state.timeLimits = {
+			timeLimit,
+			(limitWithoutPerilBonus * 0.8) + 90,
+			(limitWithoutPerilBonus * 0.6) + 90
+		}
+	else
+		self.state.timeLimits = { timeLimit, timeLimit * 0.8, timeLimit * 0.6 }
+	end
+
 	self:RenderTimer()
 end
 
-function WarpDeplete:SetKeyDetails(level, deathPenalty, affixes, affixIds, mapId)
+---@param level integer
+---@param hasChallengersPeril boolean
+---@param affixes string[]
+---@param affixIds integer[]
+---@param mapId integer
+function WarpDeplete:SetKeyDetails(level, hasChallengersPeril, affixes, affixIds, mapId)
 	self.state.level = level
-	self.state.deathPenalty = deathPenalty
+	self.state.deathPenalty = hasChallengersPeril and 15 or 5
+	self.state.hasChallengersPeril = true
 	self.state.affixes = affixes
 	self.state.affixIds = affixIds
 	self.state.mapId = mapId
 
 	self:RenderKeyDetails()
+	self:RenderLayout()
 end
 
 function WarpDeplete:LoadDeathCount()
@@ -126,28 +151,28 @@ function WarpDeplete:LoadKeyDetails()
 		return
 	end
 
-	local timeLimit = select(3, C_ChallengeMode.GetMapUIInfo(mapId))
-	self:SetTimeLimit(timeLimit)
-
 	local level, affixes = C_ChallengeMode.GetActiveKeystoneInfo()
 
-	if level <= 0 or #affixes <= 0 then
+	if not level or level <= 0 or #affixes <= 0 then
 		return
 	end
 
+	local hasChallengersPeril = false
 	local affixNames = {}
 	local affixIds = {}
-	local deathPenalty = 5
 	for i, affixID in ipairs(affixes) do
 		local name = C_ChallengeMode.GetAffixInfo(affixID)
 		affixNames[i] = Util.formatAffixName(name)
 		affixIds[i] = affixID
 		if affixID == 152 then
-			deathPenalty = 15
+			hasChallengersPeril = true
 		end
 	end
 
-	self:SetKeyDetails(level or 0, deathPenalty, affixNames, affixIds, mapId)
+	self:SetKeyDetails(level, hasChallengersPeril, affixNames, affixIds, mapId)
+
+	local timeLimit = select(3, C_ChallengeMode.GetMapUIInfo(mapId))
+	self:SetTimeLimit(timeLimit)
 end
 
 function WarpDeplete:GetEJObjectiveNames()
@@ -319,24 +344,61 @@ function WarpDeplete:UpdateObjectives()
 	end
 end
 
+function WarpDeplete:EnableChallengeMode()
+	if self.state.inChallenge then
+		self:PrintDebug("Enabling challenge mode while in challenge")
+	end
+
+	if self.state.demoModeActive then
+		self:Print(L["Disabling demo mode because a challenge has started."])
+		self:DisableDemoMode()
+	end
+
+	self:PrintDebug("Starting challenge mode")
+	self:ResetState()
+	self:RegisterChallengeEvents()
+
+	self.state.inChallenge = true
+
+	self:LoadKeyDetails()
+	self:LoadDeathCount()
+
+	self.state.ejObjectiveNames = self:GetEJObjectiveNames()
+	self:UpdateObjectives()
+
+	self:Show()
+	self:StartTimerLoop()
+end
+
+function WarpDeplete:DisableChallengeMode()
+	if self.isShown then
+		self:Hide()
+	end
+
+	if not self.state.inChallenge then
+		return
+	end
+
+	self:ResetState()
+	self:UnregisterChallengeEvents()
+end
+
 function WarpDeplete:CompleteChallenge()
 	self:StopTimerLoop()
 	self:ResetCurrentPull()
 
 	self.state.challengeCompleted = true
 	local _, _, timeMs, onTime = C_ChallengeMode.GetCompletionInfo()
-	local time = math.floor((timeMs / 1000) + 0.5)
 
 	self.state.completedOnTime = onTime
 	self.state.completionTimeMs = timeMs
-	self.state.timer = time
 
 	-- We have to complete all objectives that are not completed yet,
 	-- since we might not have gotten the final completion time
 	-- if the final objective completed the run.
 	for _, objective in pairs(self.state.objectives) do
 		if not objective.time then
-			objective.time = time
+			objective.time = self.state.timer
 		end
 	end
 
@@ -344,7 +406,7 @@ function WarpDeplete:CompleteChallenge()
 		self.state.forcesCompleted = true
 		self.state.currentCount = self.state.totalCount
 		self.state.currentPercent = 1.0
-		self.state.forcesCompletionTime = time
+		self.state.forcesCompletionTime = self.state.timer
 	end
 
 	self:UpdateSplits()

--- a/Util.lua
+++ b/Util.lua
@@ -180,7 +180,19 @@ function WarpDeplete:PrintDebug(str)
 	self:Print("|cFF479AEDDEBUG|r " .. str)
 end
 
--- TODO(happens): Add missing locales
+---@param str string
+---@return string
+function Util.trim(str)
+	return str:match("^%s*(.-)%s*$")
+end
+
+local locale = GetLocale()
+-- These should have the same names
+if locale == "enGB" then
+	locale = "enUS"
+end
+
+-- TODO: Add missing locales
 local affixNameFilters = {
 	["enUS"] = { "Xal'atath's", "Challenger's", "Bargain:" },
 	["deDE"] = { "Xal'ataths", "des Herausforderers", "Handel:" },
@@ -195,12 +207,8 @@ local affixNameFilters = {
 	["ptBR"] = {},
 }
 
-local locale = GetLocale()
--- These should have the same names
-if locale == "enGB" then
-	locale = "enUS"
-end
-
+---@param name string
+---@return string
 function Util.formatAffixName(name)
 	local result = name
 	local filters = affixNameFilters[locale] or {}
@@ -208,7 +216,34 @@ function Util.formatAffixName(name)
 		result = result:gsub(filter, "")
 	end
 
-	return result:match("^%s*(.-)%s*$")
+	return Util.trim(result)
+end
+
+-- TODO: Add missing locales
+local objectiveNameFilters = {
+	["enUS"] = { "Defeated", "defeated" },
+	["deDE"] = {},
+	["frFR"] = {},
+	["itIT"] = {},
+	["koKR"] = {},
+	["zhCN"] = {},
+	["zhTW"] = {},
+	["ruRU"] = {},
+	["esES"] = {},
+	["esMX"] = {},
+	["ptBR"] = {},
+}
+
+---@param name string
+---@return string
+function Util.formatObjectiveName(name)
+	local result = name
+	local filters = objectiveNameFilters[locale] or {}
+	for _, filter in ipairs(filters) do
+		result = result:gsub(filter, "")
+	end
+
+	return Util.trim(result)
 end
 
 -- Taken from Reloe's M+ Timer

--- a/Util.lua
+++ b/Util.lua
@@ -5,16 +5,6 @@ local Util = WarpDeplete.Util
 -- NOTE: Functions with the _OnUpdate suffix are
 -- called in the frame update loop and should not use any local vars.
 
-function Util.getBarPercent_OnUpdate(bar, percent)
-	if bar == 3 then
-		return (percent >= 0.6 and 1.0) or (percent * (10 / 6))
-	elseif bar == 2 then
-		return (percent >= 0.8 and 1.0) or (percent < 0.6 and 0) or ((percent - 0.6) * 5)
-	elseif bar == 1 then
-		return (percent < 0.8 and 0) or ((percent - 0.8) * 5)
-	end
-end
-
 local formatTime_OnUpdate_state = {}
 function Util.formatTime_OnUpdate(time)
 	formatTime_OnUpdate_state.timeMin = math.floor(time / 60)
@@ -393,4 +383,11 @@ function Util.utf8Sub(input, size)
 	end
 
 	return output
+end
+
+---@param value number
+---@param min number
+---@param max number
+function Util.clamp(value, min, max)
+	return math.min(max, math.max(min, value))
 end


### PR DESCRIPTION
We were previously only taking encounter journal boss names when the string appeared. This caused problems with bosses were the name in the EJ does not fully appear in the objective name (e.g. "Amarth, The Harvester" in the journal has the objective name "Amarth defeated").

After looking at Reloe's WeakAura again, they seem to be unconditionally using the boss name from the journal at the specified index, but then looking whether another entry fully contains the name, and switching to that if so. I don't like unconditionally retrying a fixed amount of times, but I'll need to test whether the names are actually ever unstable in game before deciding whether this is required.