### PR TITLE
a fix for the UI not showing up in tazavesh (#114)

### DIFF
--- a/Render.lua
+++ b/Render.lua
@@ -60,7 +60,7 @@ function WarpDeplete:InitRender()
 	-- Objectives
 	local objectiveTexts = {}
 
-	for i = 1, 5 do
+	for i = 1, 10 do
 		local objectiveText = self.frames.root:CreateFontString(nil, "ARTWORK")
 		objectiveTexts[i] = objectiveText
 	end
@@ -454,7 +454,7 @@ function WarpDeplete:RenderLayout()
 	currentOffset = currentOffset + barFrameHeight + barFramePaddingBottom + verticalOffset
 
 	-- Objectives
-	for i = 1, 5 do
+	for i = 1, 10 do
 		local objectiveText = self.frames.root.objectiveTexts[i]
 		objectiveText:SetFont(self.LSM:Fetch("font", objectivesFont), objectivesFontSize, objectivesFontFlags)
 		objectiveText:SetNonSpaceWrap(false)
@@ -635,7 +635,7 @@ function WarpDeplete:RenderObjectives()
 	local alignStart = self.db.profile.alignBossClear == "start"
 
 	-- Clear existing objective list
-	for i = 1, 5 do
+	for i = 1, 10 do
 		self.frames.root.objectiveTexts[i]:SetText("")
 	end
 

--- a/State.lua
+++ b/State.lua
@@ -292,48 +292,55 @@ function WarpDeplete:UpdateObjectives()
 	local completionChanged = false
 	local bossesLoaded = false
 
-	for i = 1, stepCount do
-		local info = C_ScenarioInfo.GetCriteriaInfo(i)
-		if not info.isWeightedProgress then
-			if not self.state.objectives[i] then
-				local name = self:FindObjectiveName(info.description, i)
-				self.state.objectives[i] = { name = name, description = info.description, time = nil }
-				bossesLoaded = true
-			end
+	for i = 1, 10 do
+        if i > stepCount then
+            if self.state.objectives[i] then 
+                bossesLoaded = true
+            end
+            self.state.objectives[i] = nil
+        else
+            local info = C_ScenarioInfo.GetCriteriaInfo(i)
+            if not info.isWeightedProgress then
+                if not self.state.objectives[i] then
+                    local name = self:FindObjectiveName(info.description, i)
+                    self.state.objectives[i] = { name = name, description = info.description, time = nil }
+                    bossesLoaded = true
+                end
 
-			local objective = self.state.objectives[i]
-			if not objective.time and info.completed then
-				local time = select(2, GetWorldElapsedTime(1)) - (info.elapsed or 0)
-				objective.time = time
-				completionChanged = true
-			end
-		elseif info.isWeightedProgress and info.totalQuantity and info.totalQuantity > 0 then
-			-- NOTE: The current count contains a percentage sign
-			-- even though it's an absolute value.
-			local currentCount = info.quantityString and tonumber(info.quantityString:match("%d+")) or 0
+                local objective = self.state.objectives[i]
+                if not objective.time and info.completed then
+                    local time = select(2, GetWorldElapsedTime(1)) - (info.elapsed or 0)
+                    objective.time = time
+                    completionChanged = true
+                end
+            elseif info.isWeightedProgress and info.totalQuantity and info.totalQuantity > 0 then
+                -- NOTE: The current count contains a percentage sign
+                -- even though it's an absolute value.
+                local currentCount = info.quantityString and tonumber(info.quantityString:match("%d+")) or 0
 
-			if currentCount ~= self.state.currentCount then
-				self:SetForcesCurrent(currentCount)
-			end
+                if currentCount ~= self.state.currentCount then
+                    self:SetForcesCurrent(currentCount)
+                end
 
-			if info.totalQuantity ~= self.state.totalCount then
-				self:SetForcesTotal(info.totalQuantity)
-			end
+                if info.totalQuantity ~= self.state.totalCount then
+                    self:SetForcesTotal(info.totalQuantity)
+                end
 
-			if currentCount >= info.totalQuantity then
-				if not self.state.forcesCompleted then
-					self:PrintDebug("Setting forces to completed")
-					self.state.forcesCompleted = true
-					self:RenderForces()
-				end
+                if currentCount >= info.totalQuantity then
+                    if not self.state.forcesCompleted then
+                        self:PrintDebug("Setting forces to completed")
+                        self.state.forcesCompleted = true
+                        self:RenderForces()
+                    end
 
-				if not self.state.forcesCompletionTime then
-					self:PrintDebug("Setting forces completion time")
-					self.state.forcesCompletionTime = select(2, GetWorldElapsedTime(1)) - (info.elapsed or 0)
-					completionChanged = true
-				end
-			end
-		end
+                    if not self.state.forcesCompletionTime then
+                        self:PrintDebug("Setting forces completion time")
+                        self.state.forcesCompletionTime = select(2, GetWorldElapsedTime(1)) - (info.elapsed or 0)
+                        completionChanged = true
+                    end
+                end
+            end
+        end
 	end
 
 	if bossesLoaded then


### PR DESCRIPTION
increases the number of objective fontstrings to 10, so it can render all tazavesh objectives, and update the boss fonstrings if any get removed during an update event