### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+Libs


### PR DESCRIPTION
Since the auto-package PR removes the Libs folder from the repository, but it's still required for local development and in-game usage. To prevent accidental commits, Libs has been added to .gitignore.