### PR TITLE
fix: Avoid tainting Encounter Journal UI when loading boss names

### DIFF
--- a/State.lua
+++ b/State.lua
@@ -190,22 +190,16 @@ function WarpDeplete:GetEJObjectiveNames()
 		return nil
 	end
 
-	local wasShown = EncounterJournal and EncounterJournal:IsShown()
-	if not wasShown then
-		self:PrintDebug("Opening encounter journal")
-		C_AddOns.LoadAddOn("Blizzard_EncounterJournal")
-	end
-
-	EncounterJournal_OpenJournal(8, instanceID)
-
-	if not wasShown then
-		HideUIPanel(EncounterJournal)
-	end
+	C_AddOns.LoadAddOn("Blizzard_EncounterJournal")
 
 	local result = {}
 	local encounterResults = {}
 
-	-- EJ_GetEncounterInfoByIndex requires EJ_SelectInstance to be called at least once during the session when passing a journalInstanceID to not return nil
+	-- EJ_GetEncounterInfoByIndex requires EJ_SelectInstance to be called at least once
+	-- during the session when passing a journalInstanceID to not return nil.
+	-- We use direct C API calls instead of EncounterJournal_OpenJournal to avoid
+	-- tainting the Encounter Journal UI state.
+	EJ_SetDifficulty(8)
 	EJ_SelectInstance(1267)
 
 	-- There are never more than 20 objectives

--- a/State.lua
+++ b/State.lua
@@ -199,6 +199,8 @@ function WarpDeplete:GetEJObjectiveNames()
 	-- during the session when passing a journalInstanceID to not return nil.
 	-- We use direct C API calls instead of EncounterJournal_OpenJournal to avoid
 	-- tainting the Encounter Journal UI state.
+	-- NOTE: EJ_SetDifficulty is not strictly needed since boss names don't change
+	-- across difficulties, but we set it to match the original behavior.
 	EJ_SetDifficulty(8)
 	EJ_SelectInstance(1267)
 


### PR DESCRIPTION
## Summary

Calling `EncounterJournal_OpenJournal` from addon code taints the Encounter Journal's internal UI state, which causes `MoneyFrame_Update` to error with "attempt to perform arithmetic on a secret number value (tainted by 'WarpDeplete')" when hovering over items with sell prices.

Replaced the UI-level `EncounterJournal_OpenJournal` call with direct C API calls (`EJ_SetDifficulty` + `EJ_SelectInstance`) to initialize the EJ data state without touching the UI.

## Reproduction steps

1. Enter a Mythic+ dungeon (triggers `GetEJObjectiveNames` which calls `EncounterJournal_OpenJournal`)
2. Open the Encounter Journal
3. Hover over any loot item that has a sell price
4. Observe the error: `MoneyFrame.lua:292: attempt to perform arithmetic on a secret number value (tainted by 'WarpDeplete')`