### PR TITLE
fix: Avoid comparing secret value UnitHealth

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -164,8 +164,7 @@ function WarpDeplete:COMBAT_LOG_EVENT_UNFILTERED()
 		return
 	end
 
-	-- NOTE: We have to check health since we'd count feign death otherwise
-	if UnitInParty(name) and UnitHealth(name) <= 1 then
+	if UnitInParty(name) and UnitIsDead(name) then
 		local unitName = UnitName(name)
 		local class = select(2, UnitClass(name))
 		self:AddDeathDetails(self.state.timer, unitName, class)


### PR DESCRIPTION
UnitHealth can be secret, which causes a lua error. Use UnitIsDead instead.

The comment indicates that feign death causes UnitIsDead to return 'true', but this seems to no longer be the case. I checked UnitIsDead("player") on myself and had a friend check UnitIsDead("party1") on me in Silvermoon while feigning death to test this. In both cases, UnitIsDead behaved correctly, although UnitIsFeignDeath required him to get close to me before it started returning true.